### PR TITLE
Feature 4 grid boundaries

### DIFF
--- a/lib/game_runner.rb
+++ b/lib/game_runner.rb
@@ -22,13 +22,13 @@ class GameRunner
   private
 
   def demand_valid_coordinates
-    while coordinates_invalid?
+    while !coordinate_valid?
       printer.print_coordinates_error
     end
   end
 
-  def coordinates_invalid?
-    grid.coordinates_invalid?(get_user_input)
+  def coordinate_valid?
+    grid.coordinate_valid?(get_user_input)
   end
 
   def get_user_input

--- a/lib/game_runner.rb
+++ b/lib/game_runner.rb
@@ -22,13 +22,13 @@ class GameRunner
   private
 
   def demand_valid_coordinates
-    while !coordinate_valid?
+    while coordinate_invalid?
       printer.print_coordinates_error
     end
   end
 
-  def coordinate_valid?
-    grid.coordinate_valid?(get_user_input)
+  def coordinate_invalid?
+    !grid.coordinate_valid?(get_user_input)
   end
 
   def get_user_input

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -12,8 +12,8 @@ class Grid
       GRID
     end
 
-  def coordinates_invalid?(coordinate)
-    !coordinates.include?(coordinate)
+  def coordinate_valid?(coordinate)
+    coordinates.include?(coordinate)
   end
 
   private

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -1,24 +1,24 @@
 class Grid
-    def template
-        <<~GRID
-           1  2  3
-          __ __ __
-       A |  |  |  |
-         |__|__|__|
-       B |  |  |  |
-         |__|__|__|
-       C |  |  |  |
-         |__|__|__|
-        GRID
-      end
-
-    def coordinates_invalid?(coordinate)
-      !coordinates.include?(coordinate)
+  def template
+      <<~GRID
+          1  2  3
+         __ __ __
+      A |  |  |  |
+        |__|__|__|
+      B |  |  |  |
+        |__|__|__|
+      C |  |  |  |
+        |__|__|__|
+      GRID
     end
 
-    private
-    
-    def coordinates
-      ["A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3"]
-    end
+  def coordinates_invalid?(coordinate)
+    !coordinates.include?(coordinate)
+  end
+
+  private
+
+  def coordinates
+    ["A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3"]
+  end
 end

--- a/lib/printer.rb
+++ b/lib/printer.rb
@@ -1,17 +1,17 @@
 class Printer
-    attr_reader :stdout, :grid
-  
-    def initialize(stdout, grid)
-      @stdout = stdout
-      @grid = grid
-    end
-  
-    def print_welcome_message
-      stdout.puts(grid.template)
-      stdout.puts("Enter your move >")
-    end
-  
-    def print_coordinates_error
-      stdout.puts("Invalid input. Please try again.")
-    end
+  attr_reader :stdout, :grid
+
+  def initialize(stdout, grid)
+    @stdout = stdout
+    @grid = grid
+  end
+
+  def print_welcome_message
+    stdout.puts(grid.template)
+    stdout.puts("Enter your move >")
+  end
+
+  def print_coordinates_error
+    stdout.puts("Invalid input. Please try again.")
+  end
 end

--- a/spec/game_runner_spec.rb
+++ b/spec/game_runner_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe GameRunner do
     context "on start up" do
       it "renders an empty grid with numbers at the top of each column and letters next to each row" do
         grid_template = <<~GRID
-          1  2  3
-         __ __ __
-      A |  |  |  |
-        |__|__|__|
-      B |  |  |  |
-        |__|__|__|
-      C |  |  |  |
-        |__|__|__|
-        GRID
+           1  2  3
+           __ __ __
+        A |  |  |  |
+          |__|__|__|
+        B |  |  |  |
+          |__|__|__|
+        C |  |  |  |
+          |__|__|__|
+          GRID
 
         stdout = StringIO.new
         stdin = StringIO.new
@@ -52,7 +52,7 @@ RSpec.describe GameRunner do
           |__|__|__|
         C |  |  |  |
           |__|__|__|
-          GRID_MARKED
+        GRID_MARKED
 
         game.run
 

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Grid do
       expect(grid.coordinate_valid?(valid_row_column)).to eq true
     end
 
-    it "is true if in the middle row and middle column of the grid" do
+    it "is true if somewhere in the middle of the grid" do
       valid_row_column = "B2"
       grid = Grid.new
 

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -3,18 +3,40 @@ require_relative "../lib/grid.rb"
 
 RSpec.describe Grid do
   describe "#coordinate_valid?" do
-    it "says a valid coordinate is in the coordinate values" do
-      coordinate = "A3"
+    it "validates if a row number exists in the grid" do
+      valid_row = "A3"
+      invalid_row = "A6"
       grid = Grid.new
 
-      expect(grid.coordinate_valid?(coordinate)).to eq true
+      expect(grid.coordinate_valid?(valid_row)).to eq true
+      expect(grid.coordinate_valid?(invalid_row)).to eq false
     end
 
-    it "says an invalid coordinate is not in the coordinate values" do
-      coordinate = "Z6"
+    it "validates if a column letter exists in the grid" do
+      valid_column = "A3"
+      invalid_column = "Z3"
       grid = Grid.new
 
-      expect(grid.coordinate_valid?(coordinate)).to eq false
+      expect(grid.coordinate_valid?(valid_column)).to eq true
+      expect(grid.coordinate_valid?(invalid_column)).to eq false
+    end
+
+    it "validates that the input is in the correct format" do
+      valid_format = "A3"
+      invalid_format = "3A"
+      grid = Grid.new
+
+      expect(grid.coordinate_valid?(valid_format)).to eq true
+      expect(grid.coordinate_valid?(invalid_format)).to eq false
+    end
+
+    it "validates that the first character is upper case" do
+      valid_upper_case = "A3"
+      invalid_lower_case = "a3"
+      grid = Grid.new
+
+      expect(grid.coordinate_valid?(valid_upper_case)).to eq true
+      expect(grid.coordinate_valid?(invalid_lower_case)).to eq false
     end
   end
 end

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -38,15 +38,22 @@ RSpec.describe Grid do
       expect(grid.coordinate_valid?(invalid_column)).to eq false
     end
 
-    it "is true when the input is in the correct format" do
-      valid_format = "A3"
-      grid = Grid.new
-
-      expect(grid.coordinate_valid?(valid_format)).to eq true
-    end
-
     it "is false when input is not in the correct format" do
       invalid_format = "3A"
+      grid = Grid.new
+
+      expect(grid.coordinate_valid?(invalid_format)).to eq false
+    end
+
+    it "is false when input is too many characters" do
+      invalid_format = "A3 "
+      grid = Grid.new
+
+      expect(grid.coordinate_valid?(invalid_format)).to eq false
+    end
+
+    it "is false when input is too few characters" do
+      invalid_format = "A"
       grid = Grid.new
 
       expect(grid.coordinate_valid?(invalid_format)).to eq false

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -3,39 +3,66 @@ require_relative "../lib/grid.rb"
 
 RSpec.describe Grid do
   describe "#coordinate_valid?" do
-    it "validates if a row number exists in the grid" do
+    it "is true if in the last row of the grid" do
       valid_row = "A3"
-      invalid_row = "A6"
       grid = Grid.new
 
       expect(grid.coordinate_valid?(valid_row)).to eq true
+    end
+
+    it "is false when after the last row of the grid" do
+      invalid_row = "A6"
+      grid = Grid.new
+
       expect(grid.coordinate_valid?(invalid_row)).to eq false
     end
 
-    it "validates if a column letter exists in the grid" do
+    it "is false when before the first row of the grid" do
+      invalid_row = "A0"
+      grid = Grid.new
+
+      expect(grid.coordinate_valid?(invalid_row)).to eq false
+    end
+
+    it "is true if in the last column of the grid" do
       valid_column = "A3"
-      invalid_column = "Z3"
       grid = Grid.new
 
       expect(grid.coordinate_valid?(valid_column)).to eq true
+    end
+
+    it "is false when after the last column of the grid" do
+      invalid_column = "Z3"
+      grid = Grid.new
+
       expect(grid.coordinate_valid?(invalid_column)).to eq false
     end
 
-    it "validates that the input is in the correct format" do
+    it "is true when the input is in the correct format" do
       valid_format = "A3"
-      invalid_format = "3A"
       grid = Grid.new
 
       expect(grid.coordinate_valid?(valid_format)).to eq true
+    end
+
+    it "is false when input is not in the correct format" do
+      invalid_format = "3A"
+      grid = Grid.new
+
       expect(grid.coordinate_valid?(invalid_format)).to eq false
     end
 
-    it "validates that the first character is upper case" do
+    it "is true when the first character is upper case" do
       valid_upper_case = "A3"
-      invalid_lower_case = "a3"
       grid = Grid.new
 
       expect(grid.coordinate_valid?(valid_upper_case)).to eq true
+    end
+
+    it "is false when the first character is not upper case" do
+      invalid_lower_case = "a3"
+      grid = Grid.new
+
       expect(grid.coordinate_valid?(invalid_lower_case)).to eq false
     end
   end

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require_relative "../lib/grid.rb"
+
+RSpec.describe Grid do
+  describe "#coordinate_valid?" do
+    it "says a valid coordinate is in the coordinate values" do
+      coordinate = "A3"
+      grid = Grid.new
+
+      expect(grid.coordinate_valid?(coordinate)).to eq true
+    end
+
+    it "says an invalid coordinate is not in the coordinate values" do
+      coordinate = "Z6"
+      grid = Grid.new
+
+      expect(grid.coordinate_valid?(coordinate)).to eq false
+    end
+  end
+end

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -3,36 +3,43 @@ require_relative "../lib/grid.rb"
 
 RSpec.describe Grid do
   describe "#coordinate_valid?" do
-    it "is true if in the last row of the grid" do
-      valid_row = "A3"
+    it "is true if in the first row and first column of the grid" do
+      valid_row_column = "A1"
       grid = Grid.new
 
-      expect(grid.coordinate_valid?(valid_row)).to eq true
+      expect(grid.coordinate_valid?(valid_row_column)).to eq true
+    end
+
+    it "is true if in the middle row and middle column of the grid" do
+      valid_row_column = "B2"
+      grid = Grid.new
+
+      expect(grid.coordinate_valid?(valid_row_column)).to eq true
+    end
+
+    it "is true if in the last row and last column of the grid" do
+      valid_row_column = "C3"
+      grid = Grid.new
+
+      expect(grid.coordinate_valid?(valid_row_column)).to eq true
     end
 
     it "is false when after the last row of the grid" do
-      invalid_row = "A6"
+      invalid_row = "D1"
       grid = Grid.new
 
       expect(grid.coordinate_valid?(invalid_row)).to eq false
     end
 
-    it "is false when before the first row of the grid" do
+    it "is false when before the first column of the grid" do
       invalid_row = "A0"
       grid = Grid.new
 
       expect(grid.coordinate_valid?(invalid_row)).to eq false
     end
 
-    it "is true if in the last column of the grid" do
-      valid_column = "A3"
-      grid = Grid.new
-
-      expect(grid.coordinate_valid?(valid_column)).to eq true
-    end
-
     it "is false when after the last column of the grid" do
-      invalid_column = "Z3"
+      invalid_column = "B4"
       grid = Grid.new
 
       expect(grid.coordinate_valid?(invalid_column)).to eq false
@@ -57,13 +64,6 @@ RSpec.describe Grid do
       grid = Grid.new
 
       expect(grid.coordinate_valid?(invalid_format)).to eq false
-    end
-
-    it "is true when the first character is upper case" do
-      valid_upper_case = "A3"
-      grid = Grid.new
-
-      expect(grid.coordinate_valid?(valid_upper_case)).to eq true
     end
 
     it "is false when the first character is not upper case" do


### PR DESCRIPTION
Building on learnings from [here](https://github.com/orhanna14/oo-tic-tac-toe/pull/21) and [here](https://github.com/orhanna14/oo-tic-tac-toe/pull/20)

Fix indentation to be from 4 -> 2
Move logic of coordinates to Grid
Rename methods from `coordinates` to `coordinate` because we're only looking at one coordinate at a time
Add specs for logic in grid that deal with boundaries individually. 
Boundaries include: 
- No smaller than column 1, no larger than column 3
- No larger than row C
- Correct format of input

Am I missing anything here?