### PR TITLE
Failing spec for computer marking the grid

### DIFF
--- a/spec/game_runner_spec.rb
+++ b/spec/game_runner_spec.rb
@@ -59,11 +59,14 @@ RSpec.describe GameRunner do
       end
       
       it "after the user takes a turn, the computer takes a turn, and the grid is re-rendered with an O in a random location" do
+        def seed_random_generator_for_computer_turn
+          srand
+        end
         stdout = StringIO.new
         player_turn = StringIO.new
         game = GameRunner.new(stdout, player_turn)
         expect(player_turn).to receive(:gets).and_return("C3")
-        computer_turn = srand
+        seed_random_generator_for_computer_turn
         
         grid_marked = <<~GRID_MARKED
         1  2  3

--- a/spec/game_runner_spec.rb
+++ b/spec/game_runner_spec.rb
@@ -3,7 +3,6 @@ require_relative "../lib/game_runner.rb"
 
 RSpec.describe GameRunner do
   describe "#run" do
-    context "on start up" do
       it "renders an empty grid with numbers at the top of each column and letters next to each row" do
         grid_template = <<~GRID
            1  2  3
@@ -38,7 +37,7 @@ RSpec.describe GameRunner do
         expect(stdout.string.scan(/Invalid input. Please try again./).size).to eq(2)
       end
 
-      it "when a user gives valid input renders the grid with an X inside the correct box, and then quits" do
+      it "when a user gives valid input renders the grid with an X inside the correct box" do
         stdout = StringIO.new
         stdin = StringIO.new
         game = GameRunner.new(stdout, stdin)
@@ -58,6 +57,28 @@ RSpec.describe GameRunner do
 
         expect(stdout.string).to include(grid_marked)
       end
-    end
+      
+      it "after the user takes a turn, the computer takes a turn, and the grid is re-rendered with an O in a random location" do
+        stdout = StringIO.new
+        player_turn = StringIO.new
+        game = GameRunner.new(stdout, player_turn)
+        expect(player_turn).to receive(:gets).and_return("C3")
+        computer_turn = srand
+        
+        grid_marked = <<~GRID_MARKED
+        1  2  3
+        __ __ __
+     A |O |  |  |
+       |__|__|__|
+     B |  |  |  |
+       |__|__|__|
+     C |  |  |X |
+       |__|__|__|
+        GRID_MARKED
+
+        game.run
+
+        expect(stdout.string).to include(grid_marked)
+      end
   end
 end


### PR DESCRIPTION
This PR includes a failing feature spec for feature 5:
The computer player enters the next move. It will put an O in a random location not chosen by the user. Then it re-renders the board and quits.