### PR TITLE
Refactoring players and computers

### DIFF
--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -1,0 +1,10 @@
+class Cell
+  def self.coordinates
+    ['A1', 'A2', 'A3', 'B1', 'B2', 'B3', 'C1', 'C2', 'C3']
+  end
+
+  def self.marks
+    Hash[coordinates.collect { |coordinate| [coordinate, ' '] } ]
+  end
+
+end

--- a/lib/computer_player.rb
+++ b/lib/computer_player.rb
@@ -6,7 +6,7 @@ class ComputerPlayer
     @grid = grid
   end
 
-  def get_valid_coordinate
+  def take_turn
     grid.get_valid_options(computer_choices)
     randomize_computer_choice
   end

--- a/lib/computer_player.rb
+++ b/lib/computer_player.rb
@@ -1,23 +1,15 @@
 class ComputerPlayer
-  attr_accessor :computer_choices, :grid
+  attr_accessor :grid
 
   def initialize(grid)
-    @computer_choices = []
     @grid = grid
   end
 
   def take_turn
-    grid.get_valid_options(computer_choices)
-    randomize_computer_choice
+    grid.get_valid_option
   end
 
   def marker
     'O'
-  end
-
-  private
-
-  def randomize_computer_choice
-    computer_choices[rand(computer_choices.size)]
   end
 end

--- a/lib/computer_player.rb
+++ b/lib/computer_player.rb
@@ -5,7 +5,11 @@ class ComputerPlayer
     @grid = grid
   end
 
-  def take_turn
+  def mark_grid_with_input
+    grid.mark_with_player_choice(get_valid_coordinate, marker)
+  end
+
+  def get_valid_coordinate
     grid.get_random_coordinate
   end
 

--- a/lib/computer_player.rb
+++ b/lib/computer_player.rb
@@ -6,7 +6,7 @@ class ComputerPlayer
   end
 
   def take_turn
-    grid.get_valid_option
+    grid.get_random_coordinate
   end
 
   def marker

--- a/lib/computer_player.rb
+++ b/lib/computer_player.rb
@@ -11,6 +11,10 @@ class ComputerPlayer
     randomize_computer_choice
   end
 
+  def marker
+    'O'
+  end
+
   private
 
   def randomize_computer_choice

--- a/lib/computer_player.rb
+++ b/lib/computer_player.rb
@@ -1,0 +1,18 @@
+class ComputerPlayer
+  attr_accessor :computer_choices, :grid
+
+  def initialize(grid)
+    @computer_choices = []
+    @grid = grid
+  end
+
+  def get_valid_coordinate
+    grid.structure.each { |key, value|
+    if value == " "
+      computer_choices << key
+    end
+    }
+    computer_choices[rand(computer_choices.size)]
+  end
+
+end

--- a/lib/computer_player.rb
+++ b/lib/computer_player.rb
@@ -7,12 +7,13 @@ class ComputerPlayer
   end
 
   def get_valid_coordinate
-    grid.structure.each { |key, value|
-    if value == " "
-      computer_choices << key
-    end
-    }
-    computer_choices[rand(computer_choices.size)]
+    grid.get_valid_options(computer_choices)
+    randomize_computer_choice
   end
 
+  private
+
+  def randomize_computer_choice
+    computer_choices[rand(computer_choices.size)]
+  end
 end

--- a/lib/game_runner.rb
+++ b/lib/game_runner.rb
@@ -43,12 +43,12 @@ class GameRunner
   end
 
   def player_turn
-    player.mark_grid_with_player_input
+    player.mark_grid_with_input
     print_grid
   end
 
   def computer_turn
-    mark_grid_with_computer_input
+    computer_player.mark_grid_with_input
     print_grid
   end
 
@@ -58,17 +58,5 @@ class GameRunner
 
   def print_grid
     grid_printer.print_grid
-  end
-
-  def mark_grid_with_computer_input
-    grid.mark_with_player_choice(get_computer_coordinate, computer_player_marker)
-  end
-
-  def get_computer_coordinate
-    computer_player.take_turn
-  end
-
-  def computer_player_marker
-    computer_player.marker
   end
 end

--- a/lib/game_runner.rb
+++ b/lib/game_runner.rb
@@ -61,11 +61,11 @@ class GameRunner
   end
 
   def mark_grid_with_player_input
-    grid.mark(get_valid_player_coordinate, grid.player_x)
+    grid.mark_with_player_choice(get_valid_player_coordinate)
   end
 
   def mark_grid_with_computer_input
-    grid.mark(get_computer_coordinate, grid.player_o)
+    grid.mark_with_computer_choice(get_computer_coordinate)
   end
 
   def get_computer_coordinate
@@ -75,5 +75,4 @@ class GameRunner
   def get_valid_player_coordinate
     player_input.get_valid_coordinate
   end
-
 end

--- a/lib/game_runner.rb
+++ b/lib/game_runner.rb
@@ -61,18 +61,26 @@ class GameRunner
   end
 
   def mark_grid_with_player_input
-    grid.mark_with_player_choice(get_valid_player_coordinate)
+    grid.mark_with_player_choice(get_player_coordinate, player_marker)
   end
 
   def mark_grid_with_computer_input
-    grid.mark_with_computer_choice(get_computer_coordinate)
+    grid.mark_with_player_choice(get_computer_coordinate, computer_player_marker)
   end
 
   def get_computer_coordinate
     computer_player.take_turn
   end
 
-  def get_valid_player_coordinate
+  def get_player_coordinate
     player.take_turn
+  end
+
+  def player_marker
+    player.marker
+  end
+
+  def computer_player_marker
+    computer_player.marker
   end
 end

--- a/lib/game_runner.rb
+++ b/lib/game_runner.rb
@@ -60,7 +60,7 @@ class GameRunner
   end
 
   def mark_grid_with_computer_input
-    grid.mark(grid.get_random_key, 'O')
+    grid.mark(grid.get_computer_choice, 'O')
   end
 
   def get_valid_player_coordinate

--- a/lib/game_runner.rb
+++ b/lib/game_runner.rb
@@ -1,6 +1,6 @@
 require_relative "grid"
 require_relative "printer"
-require_relative "player_input"
+require_relative "player"
 require_relative "computer_player"
 require_relative "grid_printer"
 
@@ -21,8 +21,8 @@ class GameRunner
     @grid_printer ||= GridPrinter.new(stdout, grid)
   end
 
-  def player_input
-    @player_input ||= PlayerInput.new(stdin, grid, printer)
+  def player
+    @player ||= Player.new(stdin, grid, printer)
   end
 
   def computer_player
@@ -73,6 +73,6 @@ class GameRunner
   end
 
   def get_valid_player_coordinate
-    player_input.get_valid_coordinate
+    player.get_valid_coordinate
   end
 end

--- a/lib/game_runner.rb
+++ b/lib/game_runner.rb
@@ -69,10 +69,10 @@ class GameRunner
   end
 
   def get_computer_coordinate
-    computer_player.get_valid_coordinate
+    computer_player.take_turn
   end
 
   def get_valid_player_coordinate
-    player.get_valid_coordinate
+    player.take_turn
   end
 end

--- a/lib/game_runner.rb
+++ b/lib/game_runner.rb
@@ -1,6 +1,7 @@
 require_relative "grid"
 require_relative "printer"
 require_relative "player_input"
+require_relative "computer_player"
 require_relative "grid_printer"
 
 class GameRunner
@@ -24,9 +25,13 @@ class GameRunner
     @player_input ||= PlayerInput.new(stdin, grid, printer)
   end
 
+  def computer_player
+    @computer_player ||= ComputerPlayer.new(grid)
+  end
+
   def run
     introduce_game
-    player_1_turn
+    player_turn
     computer_turn
   end
 
@@ -37,7 +42,7 @@ class GameRunner
     print_grid
   end
 
-  def player_1_turn
+  def player_turn
     mark_grid_with_player_input
     print_grid
   end
@@ -56,11 +61,15 @@ class GameRunner
   end
 
   def mark_grid_with_player_input
-    grid.mark(get_valid_player_coordinate, 'X')
+    grid.mark(get_valid_player_coordinate, grid.player_x)
   end
 
   def mark_grid_with_computer_input
-    grid.mark(grid.get_computer_choice, 'O')
+    grid.mark(get_computer_coordinate, grid.player_o)
+  end
+
+  def get_computer_coordinate
+    computer_player.get_valid_coordinate
   end
 
   def get_valid_player_coordinate

--- a/lib/game_runner.rb
+++ b/lib/game_runner.rb
@@ -43,7 +43,7 @@ class GameRunner
   end
 
   def player_turn
-    mark_grid_with_player_input
+    player.mark_grid_with_player_input
     print_grid
   end
 
@@ -60,24 +60,12 @@ class GameRunner
     grid_printer.print_grid
   end
 
-  def mark_grid_with_player_input
-    grid.mark_with_player_choice(get_player_coordinate, player_marker)
-  end
-
   def mark_grid_with_computer_input
     grid.mark_with_player_choice(get_computer_coordinate, computer_player_marker)
   end
 
   def get_computer_coordinate
     computer_player.take_turn
-  end
-
-  def get_player_coordinate
-    player.take_turn
-  end
-
-  def player_marker
-    player.marker
   end
 
   def computer_player_marker

--- a/lib/game_runner.rb
+++ b/lib/game_runner.rb
@@ -27,6 +27,7 @@ class GameRunner
   def run
     introduce_game
     player_1_turn
+    computer_turn
   end
 
   private
@@ -37,7 +38,12 @@ class GameRunner
   end
 
   def player_1_turn
-    mark_grid
+    mark_grid_with_player_input
+    print_grid
+  end
+
+  def computer_turn
+    mark_grid_with_computer_input
     print_grid
   end
 
@@ -49,11 +55,16 @@ class GameRunner
     grid_printer.print_grid
   end
 
+  def mark_grid_with_player_input
+    grid.mark(get_valid_player_coordinate, 'X')
+  end
+
+  def mark_grid_with_computer_input
+    grid.mark(grid.get_random_key, 'O')
+  end
+
   def get_valid_player_coordinate
     player_input.get_valid_coordinate
   end
 
-  def mark_grid
-    grid.mark(get_valid_player_coordinate)
-  end
 end

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -17,6 +17,16 @@ class Grid
     structure[coordinate]
   end
 
+  def get_computer_choice
+    get_random_key
+  end
+
+  private
+
+  def grid_structure
+    {"A1"=> ' ', "A2"=> ' ', "A3"=> ' ', "B1"=> ' ', "B2"=> ' ', "B3"=> ' ', "C1"=> ' ', "C2"=> ' ', "C3"=> ' '}
+  end
+
   def get_random_key
     computer_choices = []
     structure.each { |key, value|
@@ -25,11 +35,5 @@ class Grid
       end
     }
     computer_choices[rand(computer_choices.size)]
-  end
-
-  private
-
-  def grid_structure
-    {"A1"=> ' ', "A2"=> ' ', "A3"=> ' ', "B1"=> ' ', "B2"=> ' ', "B3"=> ' ', "C1"=> ' ', "C2"=> ' ', "C3"=> ' '}
   end
 end

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -1,8 +1,10 @@
+require_relative 'cell.rb'
+
 class Grid
-  attr_accessor :structure, :computer_options
+  attr_accessor :cells, :computer_options
 
   def initialize
-    @structure = build_grid
+    @cells = build_grid
     @computer_options = []
   end
 
@@ -11,15 +13,15 @@ class Grid
   end
 
   def mark(coordinate, value)
-    structure[coordinate] = value
+    cells[coordinate] = value
   end
   
   def coordinate_valid?(coordinate)
-    structure.key?(coordinate)
+    cells.key?(coordinate)
   end
 
   def get_value(coordinate)
-    structure[coordinate]
+    cells[coordinate]
   end
 
   def get_random_coordinate
@@ -30,7 +32,7 @@ class Grid
   private
 
   def get_valid_options
-    structure.each { |key, value|
+    cells.each { |key, value|
       if value == " "
         computer_options << key
       end
@@ -42,7 +44,7 @@ class Grid
   end
 
   def build_grid
-    coordinates = ['A1', 'A2', 'A3', 'B1', 'B2', 'B3', 'C1', 'C2', 'C3']
-    Hash[coordinates.collect { |coordinate| [coordinate, ' '] } ]
+    Cell.coordinates
+    Cell.marks
   end
 end

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -22,14 +22,14 @@ class Grid
     structure[coordinate]
   end
 
-  def get_valid_option
-    get_options
+  def get_random_coordinate
+    get_valid_options
     randomize_computer_choice
   end
 
   private
 
-  def get_options
+  def get_valid_options
     structure.each { |key, value|
       if value == " "
         computer_options << key

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -13,6 +13,14 @@ class Grid
     'O'
   end
 
+  def mark_with_computer_choice(valid_choice)
+    mark(valid_choice, player_o)
+  end
+
+  def mark_with_player_choice(valid_choice)
+    mark(valid_choice, player_x)
+  end
+
   def mark(coordinate, value)
     structure[coordinate] = value
   end
@@ -25,23 +33,17 @@ class Grid
     structure[coordinate]
   end
 
-  def get_computer_choice
-    get_random_key
+  def get_valid_options(computer_choices)
+    structure.each { |key, value|
+    if value == " "
+      computer_choices << key
+    end
+    }
   end
 
   private
 
   def grid_structure
     {"A1"=> ' ', "A2"=> ' ', "A3"=> ' ', "B1"=> ' ', "B2"=> ' ', "B3"=> ' ', "C1"=> ' ', "C2"=> ' ', "C3"=> ' '}
-  end
-
-  def get_random_key
-    computer_choices = []
-    structure.each { |key, value|
-      if value == " "
-        computer_choices << key
-      end
-    }
-    computer_choices[rand(computer_choices.size)]
   end
 end

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -5,20 +5,8 @@ class Grid
     @structure = build_grid
   end
 
-  def player_x
-    'X'
-  end
-
-  def player_o
-    'O'
-  end
-
-  def mark_with_computer_choice(valid_choice)
-    mark(valid_choice, player_o)
-  end
-
-  def mark_with_player_choice(valid_choice)
-    mark(valid_choice, player_x)
+  def mark_with_player_choice(valid_choice, marker)
+    mark(valid_choice, marker)
   end
 
   def mark(coordinate, value)

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -23,9 +23,9 @@ class Grid
 
   def get_valid_options(computer_choices)
     structure.each { |key, value|
-    if value == " "
-      computer_choices << key
-    end
+      if value == " "
+        computer_choices << key
+      end
     }
   end
 

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -1,8 +1,9 @@
 class Grid
-  attr_accessor :structure
+  attr_accessor :structure, :computer_options
 
   def initialize
     @structure = build_grid
+    @computer_options = []
   end
 
   def mark_with_player_choice(valid_choice, marker)
@@ -21,15 +22,24 @@ class Grid
     structure[coordinate]
   end
 
-  def get_valid_options(computer_choices)
+  def get_valid_option
+    get_options
+    randomize_computer_choice
+  end
+
+  private
+
+  def get_options
     structure.each { |key, value|
       if value == " "
-        computer_choices << key
+        computer_options << key
       end
     }
   end
 
-  private
+  def randomize_computer_choice
+    computer_options[rand(computer_options.size)]
+  end
 
   def build_grid
     coordinates = []

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -5,6 +5,14 @@ class Grid
     @structure = grid_structure
   end
 
+  def player_x
+    'X'
+  end
+
+  def player_o
+    'O'
+  end
+
   def mark(coordinate, value)
     structure[coordinate] = value
   end

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -42,20 +42,7 @@ class Grid
   end
 
   def build_grid
-    coordinates = []
-    row.each do |letter|
-      column.each do |number|
-         coordinates.push(letter + number)
-      end
-    end
+    coordinates = ['A1', 'A2', 'A3', 'B1', 'B2', 'B3', 'C1', 'C2', 'C3']
     Hash[coordinates.collect { |coordinate| [coordinate, ' '] } ]
-  end
-
-  def row
-    ['A', 'B', 'C']
-  end
-
-  def column
-    ['1', '2', '3']
   end
 end

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -5,8 +5,8 @@ class Grid
     @structure = grid_structure
   end
 
-  def mark(coordinate)
-    structure[coordinate] = 'X'
+  def mark(coordinate, value)
+    structure[coordinate] = value
   end
   
   def coordinate_valid?(coordinate)
@@ -15,6 +15,11 @@ class Grid
 
   def get_value(coordinate)
     structure[coordinate]
+  end
+
+  def get_random_key
+    grid_keys = structure.keys
+    grid_keys[rand(grid_keys.size)]
   end
 
   private

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -2,7 +2,7 @@ class Grid
   attr_accessor :structure
 
   def initialize
-    @structure = grid_structure
+    @structure = build_grid
   end
 
   def player_x
@@ -43,7 +43,21 @@ class Grid
 
   private
 
-  def grid_structure
-    {"A1"=> ' ', "A2"=> ' ', "A3"=> ' ', "B1"=> ' ', "B2"=> ' ', "B3"=> ' ', "C1"=> ' ', "C2"=> ' ', "C3"=> ' '}
+  def build_grid
+    coordinates = []
+    row.each do |letter|
+      column.each do |number|
+         coordinates.push(letter + number)
+      end
+    end
+    Hash[coordinates.collect { |coordinate| [coordinate, ' '] } ]
+  end
+
+  def row
+    ['A', 'B', 'C']
+  end
+
+  def column
+    ['1', '2', '3']
   end
 end

--- a/lib/grid.rb
+++ b/lib/grid.rb
@@ -18,8 +18,13 @@ class Grid
   end
 
   def get_random_key
-    grid_keys = structure.keys
-    grid_keys[rand(grid_keys.size)]
+    computer_choices = []
+    structure.each { |key, value|
+      if value == " "
+        computer_choices << key
+      end
+    }
+    computer_choices[rand(computer_choices.size)]
   end
 
   private

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -10,7 +10,11 @@ class Player
     @printer = printer
   end
 
-  def take_turn
+  def mark_grid_with_player_input
+    grid.mark_with_player_choice(get_valid_coordinate, marker)
+  end
+
+  def get_valid_coordinate
     until coordinates.valid?(grid)
       ask_for_coordinate_and_print_error
     end

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -1,7 +1,7 @@
 require_relative "coordinates"
 require_relative "null_coordinates"
 
-class PlayerInput
+class Player
   attr_reader :stdin, :grid, :printer
   
   def initialize(stdin, grid, printer)
@@ -17,15 +17,15 @@ class PlayerInput
     coordinates.value
   end
 
+  private
+
   def ask_for_coordinate_and_print_error
     get_user_coordinate
     unless coordinates.valid?(grid)
       printer.print_coordinates_error
     end
   end
-
-  private
-
+  
   def coordinates
     @coordinates ||= NullCoordinates.new
   end

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -17,6 +17,10 @@ class Player
     coordinates.value
   end
 
+  def marker
+    'X'
+  end
+
   private
 
   def ask_for_coordinate_and_print_error

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -10,7 +10,7 @@ class Player
     @printer = printer
   end
 
-  def get_valid_coordinate
+  def take_turn
     until coordinates.valid?(grid)
       ask_for_coordinate_and_print_error
     end

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -10,7 +10,7 @@ class Player
     @printer = printer
   end
 
-  def mark_grid_with_player_input
+  def mark_grid_with_input
     grid.mark_with_player_choice(get_valid_coordinate, marker)
   end
 

--- a/spec/computer_player_spec.rb
+++ b/spec/computer_player_spec.rb
@@ -3,7 +3,7 @@ require_relative "../lib/computer_player.rb"
 require_relative "../lib/grid.rb"
 
 RSpec.describe ComputerPlayer do
-  describe "#get_valid_coordinate" do
+  describe "#take_turn" do
     it "gives the computer all choices that are available" do
       srand(0)
       coordinate_1 = "A1"
@@ -21,7 +21,7 @@ RSpec.describe ComputerPlayer do
       grid.mark(coordinate_2, value_2)
       grid.mark(coordinate_3, value_3)
       
-      choice = computer_player.get_valid_coordinate
+      choice = computer_player.take_turn
 
       expect(valid_options).to include(choice)
     end

--- a/spec/computer_player_spec.rb
+++ b/spec/computer_player_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require_relative "../lib/computer_player.rb"
+require_relative "../lib/grid.rb"
+
+RSpec.describe ComputerPlayer do
+  describe "#get_valid_coordinate" do
+    it "gives the computer all choices that are available" do
+      srand(0)
+      coordinate_1 = "A1"
+      value_1 = 'X'
+      coordinate_2 = "B2"
+      value_2 = 'O'
+      coordinate_3 = "C3"
+      value_3 = 'X'
+
+      grid = Grid.new
+      computer_player = ComputerPlayer.new(grid)
+      valid_options = ["A2", "B1", "B3", "C1", "C2"]
+
+      grid.mark(coordinate_1, value_1)
+      grid.mark(coordinate_2, value_2)
+      grid.mark(coordinate_3, value_3)
+      
+      choice = computer_player.get_valid_coordinate
+
+      expect(valid_options).to include(choice)
+    end
+  end
+end

--- a/spec/computer_player_spec.rb
+++ b/spec/computer_player_spec.rb
@@ -3,7 +3,7 @@ require_relative "../lib/computer_player.rb"
 require_relative "../lib/grid.rb"
 
 RSpec.describe ComputerPlayer do
-  describe "#take_turn" do
+  describe "#get_valid_coordinate" do
     it "gives the computer all choices that are available" do
       srand(0)
       coordinate_1 = "A1"
@@ -21,7 +21,7 @@ RSpec.describe ComputerPlayer do
       grid.mark(coordinate_2, value_2)
       grid.mark(coordinate_3, value_3)
       
-      choice = computer_player.take_turn
+      choice = computer_player.get_valid_coordinate
 
       expect(valid_options).to include(choice)
     end

--- a/spec/game_runner_spec.rb
+++ b/spec/game_runner_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe GameRunner do
       
       it "after the user takes a turn, the computer takes a turn, and the grid is re-rendered with an O in a random location" do
         def seed_random_generator_for_computer_turn
-          srand
+          srand(0)
         end
         stdout = StringIO.new
         player_turn = StringIO.new
@@ -71,9 +71,9 @@ RSpec.describe GameRunner do
         grid_marked = <<~GRID_MARKED
         1  2  3
         __ __ __
-     A |O |  |  |
+     A |  |  |  |
        |__|__|__|
-     B |  |  |  |
+     B |  |O |  |
        |__|__|__|
      C |  |  |X |
        |__|__|__|

--- a/spec/game_runner_spec.rb
+++ b/spec/game_runner_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require_relative "../lib/game_runner.rb"
+require_relative "helper_methods"
 
 RSpec.describe GameRunner do
   describe "#run" do
@@ -59,9 +60,6 @@ RSpec.describe GameRunner do
       end
       
       it "after the user takes a turn, the computer takes a turn, and the grid is re-rendered with an O in a random location" do
-        def seed_random_generator_for_computer_turn
-          srand(0)
-        end
         stdout = StringIO.new
         player_turn = StringIO.new
         game = GameRunner.new(stdout, player_turn)

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Grid do
     end
   end
 
-  describe "#get_valid_option" do
+  describe "#get_random_coordinate" do
     it "gives the computer all choices that are available" do
       srand(0)
       coordinate_1 = "A1"
@@ -92,7 +92,7 @@ RSpec.describe Grid do
       grid.mark(coordinate_2, value_2)
       grid.mark(coordinate_3, value_3)
       
-      randomized_computer_choice = grid.get_valid_option
+      randomized_computer_choice = grid.get_random_coordinate
 
       expect(remaining_options).to include(randomized_computer_choice)
     end

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Grid do
     end
   end
 
-  describe "#get_valid_options" do
+  describe "#get_valid_option" do
     it "gives the computer all choices that are available" do
       srand(0)
       coordinate_1 = "A1"
@@ -84,16 +84,17 @@ RSpec.describe Grid do
       coordinate_3 = "C3"
       value_3 = 'X'
 
+      remaining_options = ["A2", "A3", "B1", "B3", "C1", "C2"]
+
       grid = Grid.new
-      valid_options = []
 
       grid.mark(coordinate_1, value_1)
       grid.mark(coordinate_2, value_2)
       grid.mark(coordinate_3, value_3)
       
-      grid.get_valid_options(valid_options)
+      randomized_computer_choice = grid.get_valid_option
 
-      expect(valid_options).to eq(["A2", "A3", "B1", "B3", "C1", "C2"])
+      expect(remaining_options).to include(randomized_computer_choice)
     end
   end
 

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -109,23 +109,21 @@ RSpec.describe Grid do
     end
   end
 
-  describe "#mark_with_computer_choice" do
-    it "assigns O to the valid coordinates" do
-      grid = Grid.new
-
-      grid.mark_with_computer_choice("A1")
-
-      expect(grid.get_value("A1")).to eq("O")
-    end
-  end
-
   describe "#mark_with_player_choice" do
   it "assigns X to the valid coordinates" do
     grid = Grid.new
 
-    grid.mark_with_player_choice("A1")
+    grid.mark_with_player_choice("A1", 'X')
 
     expect(grid.get_value("A1")).to eq("X")
+  end
+
+  it "assigns O to the valid coordinates" do
+    grid = Grid.new
+
+    grid.mark_with_player_choice("A1", 'O')
+
+    expect(grid.get_value("A1")).to eq("O")
   end
 end
 end

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -74,22 +74,58 @@ RSpec.describe Grid do
     end
   end
 
-  it "#mark takes in a valid coordinate, and gives it a marked value in coordinates" do
-    coordinate = "A3"
-    value = 'X'
-    grid = Grid.new
+  describe "#get_valid_options" do
+    it "gives the computer all choices that are available" do
+      srand(0)
+      coordinate_1 = "A1"
+      value_1 = 'X'
+      coordinate_2 = "B2"
+      value_2 = 'O'
+      coordinate_3 = "C3"
+      value_3 = 'X'
 
-    grid.mark(coordinate, value)
+      grid = Grid.new
+      valid_options = []
 
-    expect(grid.get_value(coordinate)).to eq('X')
+      grid.mark(coordinate_1, value_1)
+      grid.mark(coordinate_2, value_2)
+      grid.mark(coordinate_3, value_3)
+      
+      grid.get_valid_options(valid_options)
+
+      expect(valid_options).to eq(["A2", "A3", "B1", "B3", "C1", "C2"])
+    end
   end
 
-  it "#get_computer_choice returns a random key from the structure" do
-    grid = Grid.new
-    valid_keys = ["A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3"]
+  describe "#mark" do
+    it "marks a valid coordinate in the grid" do
+      coordinate = "A3"
+      value = 'X'
+      grid = Grid.new
 
-    computer_coordinate = grid.get_computer_choice
+      grid.mark(coordinate, value)
 
-    expect(valid_keys).to include(computer_coordinate)
+      expect(grid.get_value(coordinate)).to eq('X')
+    end
   end
+
+  describe "#mark_with_computer_choice" do
+    it "assigns O to the valid coordinates" do
+      grid = Grid.new
+
+      grid.mark_with_computer_choice("A1")
+
+      expect(grid.get_value("A1")).to eq("O")
+    end
+  end
+
+  describe "#mark_with_player_choice" do
+  it "assigns X to the valid coordinates" do
+    grid = Grid.new
+
+    grid.mark_with_player_choice("A1")
+
+    expect(grid.get_value("A1")).to eq("X")
+  end
+end
 end

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -84,11 +84,11 @@ RSpec.describe Grid do
     expect(grid.get_value(coordinate)).to eq('X')
   end
 
-  it "#get_random_key returns a random key from the structure" do
+  it "#get_computer_choice returns a random key from the structure" do
     grid = Grid.new
     valid_keys = ["A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3"]
 
-    computer_coordinate = grid.get_random_key
+    computer_coordinate = grid.get_computer_choice
 
     expect(valid_keys).to include(computer_coordinate)
   end

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -73,14 +73,23 @@ RSpec.describe Grid do
       expect(grid.coordinate_valid?(invalid_lower_case)).to eq false
     end
   end
-  describe "#mark" do
-    it "takes in a valid coordinate, and gives it a marked value in coordinates" do
-      coordinate = "A3"
-      grid = Grid.new
 
-      grid.mark(coordinate)
+  it "#mark takes in a valid coordinate, and gives it a marked value in coordinates" do
+    coordinate = "A3"
+    value = 'X'
+    grid = Grid.new
 
-      expect(grid.get_value(coordinate)).to eq('X')
-    end
+    grid.mark(coordinate, value)
+
+    expect(grid.get_value(coordinate)).to eq('X')
+  end
+
+  it "#get_random_key returns a random key from the structure" do
+    grid = Grid.new
+    valid_keys = ["A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "C3"]
+
+    computer_coordinate = grid.get_random_key
+
+    expect(valid_keys).to include(computer_coordinate)
   end
 end

--- a/spec/helper_methods.rb
+++ b/spec/helper_methods.rb
@@ -1,0 +1,3 @@
+def seed_random_generator_for_computer_turn
+  srand(0)
+end

--- a/spec/player_input_spec.rb
+++ b/spec/player_input_spec.rb
@@ -1,20 +1,20 @@
 require "spec_helper"
-require_relative "../lib/player_input.rb"
+require_relative "../lib/player.rb"
 require_relative "../lib/coordinates.rb"
 require_relative "../lib/grid.rb"
 require_relative "../lib/printer.rb"
 
-RSpec.describe PlayerInput do
+RSpec.describe Player do
   describe "#get_valid_coordinate" do
      it "repeatedly asks for valid coordinate, returns the value when valid" do
       invalid_format = StringIO.new
       grid = Grid.new
       printer = Printer.new(invalid_format)
-      player_input = PlayerInput.new(invalid_format, grid, printer)
+      player = Player.new(invalid_format, grid, printer)
       allow(invalid_format).to receive(:gets).and_return("A6", "B7", "A1")
       coordinates = Coordinates.new(invalid_format)
 
-      result = player_input.get_valid_coordinate
+      result = player.get_valid_coordinate
 
       expect(result).to eq("A1")
     end

--- a/spec/player_spec.rb
+++ b/spec/player_spec.rb
@@ -5,7 +5,7 @@ require_relative "../lib/grid.rb"
 require_relative "../lib/printer.rb"
 
 RSpec.describe Player do
-  describe "#take_turn" do
+  describe "#get_valid_coordinate" do
      it "repeatedly asks for valid coordinate, returns the value when valid" do
       player_input = StringIO.new
       grid = Grid.new
@@ -14,7 +14,7 @@ RSpec.describe Player do
       allow(player_input).to receive(:gets).and_return("A6", "B7", "A1")
       coordinates = Coordinates.new(player_input)
 
-      result = player.take_turn
+      result = player.get_valid_coordinate
 
       expect(result).to eq("A1")
     end

--- a/spec/player_spec.rb
+++ b/spec/player_spec.rb
@@ -5,16 +5,16 @@ require_relative "../lib/grid.rb"
 require_relative "../lib/printer.rb"
 
 RSpec.describe Player do
-  describe "#get_valid_coordinate" do
+  describe "#take_turn" do
      it "repeatedly asks for valid coordinate, returns the value when valid" do
-      invalid_format = StringIO.new
+      player_input = StringIO.new
       grid = Grid.new
-      printer = Printer.new(invalid_format)
-      player = Player.new(invalid_format, grid, printer)
-      allow(invalid_format).to receive(:gets).and_return("A6", "B7", "A1")
-      coordinates = Coordinates.new(invalid_format)
+      printer = Printer.new(player_input)
+      player = Player.new(player_input, grid, printer)
+      allow(player_input).to receive(:gets).and_return("A6", "B7", "A1")
+      coordinates = Coordinates.new(player_input)
 
-      result = player.get_valid_coordinate
+      result = player.take_turn
 
       expect(result).to eq("A1")
     end


### PR DESCRIPTION
This PR takes a stab at refactoring some of the issues brought up [here](https://github.com/orhanna14/oo-tic-tac-toe/pull/31).

- It moves the data from the `Grid` class to the `Cell` class. 
- The `Player` and `ComputerPlayer` now maintain their own markers. 
- The `Grid` is now sending the `ComputerPlayer` a single random option for their turn. 